### PR TITLE
Add settings for 'No streams found' text for issue #12

### DIFF
--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -116,6 +116,15 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array('label_for' => 'tp_twitch_no_streams_found')
 			);
 
+			add_settings_field(
+				'tp_twitch_no_streams_found_text',
+				__( 'No Streams Found Message', 'tomparisde-twitchtv-widget' ),
+				array( &$this, 'no_streams_found_text_render' ),
+				'tp_twitch',
+				'tp_twitch_general',
+				array( 'label_for' => 'tp_twitch_no_streams_found_text' )
+			);
+
 			do_action( 'tp_twitch_register_general_settings' );
 
 			add_settings_section(
@@ -399,6 +408,21 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
             </select>
             <p class="description">
 				<?php _e('Specify what happens when no streams were found.', 'tomparisde-twitchtv-widget' ); ?>
+            </p>
+			<?php
+		}
+
+		/**
+		 * No streams found text
+		 */
+		function no_streams_found_text_render() {
+
+            $no_streams_found_message = ( isset ( $this->options['no_streams_found_text'] ) ) ? $this->options['no_streams_found_text'] : __( 'No streams found', 'tomparisde-twitchtv-widget' );
+
+			?>
+            <input id="tp_twitch_no_streams_found_text" class="regular-text" name="tp_twitch[no_streams_found_text]" type="text" value="<?php echo esc_html( $no_streams_found_message ); ?>" />
+            <p class="description">
+                <?php _e( 'Customize the message displayed when they are no available streams.', 'tomparisde-twitchtv-widget' ); ?>
             </p>
 			<?php
 		}

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 
             add_settings_section(
                 'tp_twitch_quickstart',
-                __('Quickstart Guide', 'tomparisde-twitchtv-widget'),
+                __( 'Quickstart Guide', 'tomparisde-twitchtv-widget' ),
                 array( &$this, 'section_quickstart_render' ),
                 'tp_twitch'
             );
@@ -77,7 +77,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array( &$this, 'api_status_render' ),
 				'tp_twitch',
 				'tp_twitch_api',
-				array('label_for' => 'tp_twitch_api_status')
+				array( 'label_for' => 'tp_twitch_api_status' )
 			);
 
 			add_settings_field(
@@ -86,7 +86,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array( &$this, 'api_client_id_render' ),
 				'tp_twitch',
 				'tp_twitch_api',
-				array('label_for' => 'tp_twitch_api_client_id')
+				array( 'label_for' => 'tp_twitch_api_client_id' )
 			);
 
 			do_action( 'tp_twitch_register_api_settings' );
@@ -104,7 +104,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array( &$this, 'cache_duration_render' ),
 				'tp_twitch',
                 'tp_twitch_general',
-				array('label_for' => 'tp_twitch_cache_duration')
+				array( 'label_for' => 'tp_twitch_cache_duration' )
 			);
 
 			add_settings_field(
@@ -113,7 +113,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array( &$this, 'no_streams_found_render' ),
 				'tp_twitch',
 				'tp_twitch_general',
-				array('label_for' => 'tp_twitch_no_streams_found')
+				array( 'label_for' => 'tp_twitch_no_streams_found' )
 			);
 
 			add_settings_field(
@@ -140,7 +140,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                 array( &$this, 'language_render' ),
                 'tp_twitch',
                 'tp_twitch_defaults',
-                array('label_for' => 'tp_twitch_language')
+                array( 'label_for' => 'tp_twitch_language' )
             );
 
             add_settings_field(
@@ -149,7 +149,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                 array( &$this, 'widget_style_render' ),
                 'tp_twitch',
                 'tp_twitch_defaults',
-                array('label_for' => 'tp_twitch_widget_style')
+                array( 'label_for' => 'tp_twitch_widget_style' )
             );
 
 			add_settings_field(
@@ -158,7 +158,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array( &$this, 'widget_size_render' ),
 				'tp_twitch',
 				'tp_twitch_defaults',
-				array('label_for' => 'tp_twitch_widget_size')
+				array( 'label_for' => 'tp_twitch_widget_size' )
 			);
 
 			add_settings_field(
@@ -167,7 +167,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				array( &$this, 'widget_preview_render' ),
 				'tp_twitch',
 				'tp_twitch_defaults',
-				array('label_for' => 'tp_twitch_widget_preview')
+				array( 'label_for' => 'tp_twitch_widget_preview' )
 			);
 
 			do_action( 'tp_twitch_register_defaults_settings' );
@@ -208,11 +208,11 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 
             // API
 			$api_status = ( isset ( $this->options['api_status'] ) ) ? $this->options['api_status'] : false;
-			$api_error = ( isset ( $this->options['api_error'] ) ) ? $this->options['api_error'] : '';
+			$api_error  = ( isset ( $this->options['api_error'] ) ) ? $this->options['api_error'] : '';
 
 			if ( ! empty ( $input['api_client_id'] ) ) {
 
-				$api_client_id = ( isset ( $this->options['api_client_id'] ) ) ? $this->options['api_client_id'] : '';
+				$api_client_id     = ( isset ( $this->options['api_client_id'] ) ) ? $this->options['api_client_id'] : '';
 				$api_client_id_new = $input['api_client_id'];
 
 				if ( $api_client_id_new != $api_client_id ) {
@@ -220,7 +220,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 					$result = tp_twitch()->api->verify_client_id( $api_client_id_new );
 
 					$api_status = ( is_array( $result ) && isset( $result['data'] ) ) ? true : false;
-					$api_error = ( ! empty ( $result['error'] ) ) ? $result['error'] : '';
+					$api_error  = ( ! empty ( $result['error'] ) ) ? $result['error'] : '';
 
 					if ( ! empty ( $api_error ) )
 					    tp_twitch_addlog( 'Twitch API >> Verify client id >> Error: "' . $api_error . '"' );
@@ -232,7 +232,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
             }
 
 			$input['api_status'] = $api_status;
-			$input['api_error'] = $api_error;
+			$input['api_error']  = $api_error;
 
 			// Cache duration changed
             if ( isset( $input['cache_duration'] ) && isset( $this->options['cache_duration'] ) && $input['cache_duration'] != $this->options['cache_duration'] ) {
@@ -241,7 +241,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 
             // Handle Delete Cache Action
 			if ( isset ( $input['delete_cache'] ) && '1' === $input['delete_cache'] ) {
-				$delete_cache = true;
+				$delete_cache          = true;
 				$input['delete_cache'] = '0';
 			}
 
@@ -280,7 +280,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 
             <p>
                 <strong><?php _e( 'Step 2: Enter your Client ID', 'tomparisde-twitchtv-widget' ); ?></strong><br />
-                <?php _e('Once you created your API credentials, enter your personal <em>Client ID</em> into the field below.', 'tomparisde-twitchtv-widget'); ?>
+                <?php _e( 'Once you created your API credentials, enter your personal <em>Client ID</em> into the field below.', 'tomparisde-twitchtv-widget' ); ?>
             </p>
 
             <p>
@@ -314,7 +314,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 		function api_status_render() {
 
 			$api_status = ( isset ( $this->options['api_status'] ) && true === $this->options['api_status'] ) ? true : false;
-			$api_error = ( isset( $this->options['api_error'] ) ) ? $this->options['api_error'] : '';
+			$api_error  = ( isset( $this->options['api_error'] ) ) ? $this->options['api_error'] : '';
 			?>
             <?php if ( $api_status ) { ?>
                 <span style="font-weight: bold; color: green;"><?php _e( 'Connected', 'tomparisde-twitchtv-widget' ); ?></span>
@@ -353,7 +353,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 		function section_general_render() {
 
 			?>
-            <p><?php _e('Here you set up general settings which will be used plugin wide.', 'tomparisde-twitchtv-widget' ); ?></p>
+            <p><?php _e( 'Here you set up general settings which will be used plugin wide.', 'tomparisde-twitchtv-widget' ); ?></p>
 			<?php
 		}
 
@@ -363,11 +363,11 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 		function cache_duration_render() {
 
 			$cache_duration_options = array(
-                1 => sprintf( esc_html( _n( '%d hour', '%d hours', 1, 'tomparisde-twitchtv-widget'  ) ), 1 ),
-                2 => sprintf( esc_html( _n( '%d hour', '%d hours', 2, 'tomparisde-twitchtv-widget'  ) ), 2 ),
-                3 => sprintf( esc_html( _n( '%d hour', '%d hours', 3, 'tomparisde-twitchtv-widget'  ) ), 3 ),
-                4 => sprintf( esc_html( _n( '%d hour', '%d hours', 4, 'tomparisde-twitchtv-widget'  ) ), 4 ),
-				6 => sprintf( esc_html( _n( '%d hour', '%d hours', 6, 'tomparisde-twitchtv-widget'  ) ), 6 ),
+                1  => sprintf( esc_html( _n( '%d hour', '%d hours', 1, 'tomparisde-twitchtv-widget'  ) ), 1 ),
+                2  => sprintf( esc_html( _n( '%d hour', '%d hours', 2, 'tomparisde-twitchtv-widget'  ) ), 2 ),
+                3  => sprintf( esc_html( _n( '%d hour', '%d hours', 3, 'tomparisde-twitchtv-widget'  ) ), 3 ),
+                4  => sprintf( esc_html( _n( '%d hour', '%d hours', 4, 'tomparisde-twitchtv-widget'  ) ), 4 ),
+				6  => sprintf( esc_html( _n( '%d hour', '%d hours', 6, 'tomparisde-twitchtv-widget'  ) ), 6 ),
 				12 => sprintf( esc_html( _n( '%d hour', '%d hours', 12, 'tomparisde-twitchtv-widget'  ) ), 12 ),
 				24 => sprintf( esc_html( _n( '%d hour', '%d hours', 24, 'tomparisde-twitchtv-widget'  ) ), 24 )
             );
@@ -381,7 +381,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				<?php } ?>
             </select>
             <p class="description">
-                <?php _e('In case you\'re using a caching plugin, it makes no sense to select a lower value, than the caching interval of your caching plugin.', 'tomparisde-twitchtv-widget' ); ?>
+                <?php _e( 'In case you\'re using a caching plugin, it makes no sense to select a lower value, than the caching interval of your caching plugin.', 'tomparisde-twitchtv-widget' ); ?>
             </p>
             <input type="hidden" id="tp_twitch_delete_cache" name="tp_twitch[delete_cache]" value="0" />
 			<?php
@@ -393,8 +393,8 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 		function no_streams_found_render() {
 
 			$no_streams_found_options = array(
-				'' => __( 'Hide Message', 'tomparisde-twitchtv-widget' ),
-				'show' => __( 'Show Message', 'tomparisde-twitchtv-widget' ),
+				''      => __( 'Hide Message', 'tomparisde-twitchtv-widget' ),
+				'show'  => __( 'Show Message', 'tomparisde-twitchtv-widget' ),
 				'admin' => __( 'Show Message for Admins only', 'tomparisde-twitchtv-widget' )
 			);
 
@@ -407,7 +407,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 				<?php } ?>
             </select>
             <p class="description">
-				<?php _e('Specify what happens when no streams were found.', 'tomparisde-twitchtv-widget' ); ?>
+				<?php _e( 'Specify what happens when no streams were found.', 'tomparisde-twitchtv-widget' ); ?>
             </p>
 			<?php
 		}
@@ -433,7 +433,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 		function section_defaults_render() {
 
 		    ?>
-            <p><?php _e('Here you set up the default settings which will be used for displaying streams and may be overwritten individually.', 'tomparisde-twitchtv-widget' ); ?></p>
+            <p><?php _e( 'Here you set up the default settings which will be used for displaying streams and may be overwritten individually.', 'tomparisde-twitchtv-widget' ); ?></p>
             <?php
         }
 
@@ -514,10 +514,10 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
             if ( ! isset( $this->options['api_status'] ) || ! $this->options['api_status'] )
                 return;
             ?>
-            <p><?php _e('Here you can find an overview of all available API related data.', 'tomparisde-twitchtv-widget' ); ?></p>
+            <p><?php _e( 'Here you can find an overview of all available API related data.', 'tomparisde-twitchtv-widget' ); ?></p>
 
             <p>
-                <span id="tp-twitch-data-toggle" class="button button-secondary"><?php _e('Toggle Information', 'tomparisde-twitchtv-widget' ); ?></span>
+                <span id="tp-twitch-data-toggle" class="button button-secondary"><?php _e( 'Toggle Information', 'tomparisde-twitchtv-widget' ); ?></span>
             </p>
             <div id="tp-twitch-data-container" style="display: none;">
                 <?php
@@ -528,12 +528,12 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                     $games = tp_twitch_array_sort( $games, 'name' );
 
                 if ( $games && is_array( $games ) && sizeof( $games ) > 0 ) { ?>
-                    <h4><?php _e('Games','tomparisde-twitchtv-widget' ); ?></h4>
+                    <h4><?php _e( 'Games','tomparisde-twitchtv-widget' ); ?></h4>
                     <table class="widefat">
                         <thead>
                             <tr>
-                                <th><?php _e('ID', 'tomparisde-twitchtv-widget' ); ?></th>
-                                <th><?php _e('Game', 'tomparisde-twitchtv-widget' ); ?></th>
+                                <th><?php _e( 'ID', 'tomparisde-twitchtv-widget' ); ?></th>
+                                <th><?php _e( 'Game', 'tomparisde-twitchtv-widget' ); ?></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -553,14 +553,14 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                 }
 
                 $languages = tp_twitch_get_languages();
-                asort($languages );
+                asort( $languages );
                 ?>
-                <h4><?php _e('Languages','tomparisde-twitchtv-widget' ); ?></h4>
+                <h4><?php _e( 'Languages','tomparisde-twitchtv-widget' ); ?></h4>
                 <table class="widefat">
                     <thead>
                     <tr>
-                        <th><?php _e('Code', 'tomparisde-twitchtv-widget' ); ?></th>
-                        <th><?php _e('Language', 'tomparisde-twitchtv-widget' ); ?></th>
+                        <th><?php _e( 'Code', 'tomparisde-twitchtv-widget' ); ?></th>
+                        <th><?php _e( 'Language', 'tomparisde-twitchtv-widget' ); ?></th>
                     </tr>
                     </thead>
                     <tbody>
@@ -589,8 +589,8 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
             
             $curl = $this->check_curl();
 
-            $enabled = '<span style="color: green;"><strong><span class="dashicons dashicons-yes"></span> ' . __('Enabled', 'tomparisde-twitchtv-widget') . '</strong></span>';
-            $disabled = '<span style="color: red;"><strong><span class="dashicons dashicons-no"></span> ' . __('Disabled', 'tomparisde-twitchtv-widget') . '</strong></span>';
+            $enabled  = '<span style="color: green;"><strong><span class="dashicons dashicons-yes"></span> ' . __( 'Enabled', 'tomparisde-twitchtv-widget' ) . '</strong></span>';
+            $disabled = '<span style="color: red;"><strong><span class="dashicons dashicons-no"></span> ' . __( 'Disabled', 'tomparisde-twitchtv-widget' ) . '</strong></span>';
 
             ?>
             <p>
@@ -600,8 +600,8 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
             <table class="widefat tp-twitch-settings-table">
                 <thead>
                 <tr>
-                    <th width="300"><?php _e('Setting', 'tomparisde-twitchtv-widget'); ?></th>
-                    <th><?php _e('Values', 'tomparisde-twitchtv-widget'); ?></th>
+                    <th width="300"><?php _e( 'Setting', 'tomparisde-twitchtv-widget' ); ?></th>
+                    <th><?php _e( 'Values', 'tomparisde-twitchtv-widget' ); ?></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -626,19 +626,19 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                 <tr>
                     <th><?php printf( esc_html__( 'PHP "%1$s" extension', 'tomparisde-twitchtv-widget' ), 'cURL' ); ?></th>
                     <td>
-                        <?php echo (isset ($curl['enabled']) && $curl['enabled']) ? $enabled : $disabled; ?>
-                        <?php if (isset ($curl['version'])) echo ' (Version ' . $curl['version'] . ')'; ?>
+                        <?php echo ( isset ( $curl['enabled'] ) && $curl['enabled'] ) ? $enabled : $disabled; ?>
+                        <?php if ( isset ( $curl['version'] ) ) echo ' (Version ' . $curl['version'] . ' )'; ?>
                     </td>
                 </tr>
                 </tbody>
             </table>
 
             <p>
-                <?php _e('In case one of the values above is <span style="color: red;"><strong>red</strong></span>, please get in contact with your webhoster in order to enable the missing PHP extensions.', 'tomparisde-twitchtv-widget'); ?>
+                <?php _e( 'In case one of the values above is <span style="color: red;"><strong>red</strong></span>, please get in contact with your webhoster in order to enable the missing PHP extensions.', 'tomparisde-twitchtv-widget' ); ?>
             </p>
 
             <p>
-                <strong><?php _e('Log file', 'tomparisde-twitchtv-widget'); ?></strong><br />
+                <strong><?php _e( 'Log file', 'tomparisde-twitchtv-widget' ); ?></strong><br />
                 <textarea rows="5" style="width: 100%;"><?php echo get_option( 'tp_twitch_log', __( 'No entries yet. ', 'tomparisde-twitchtv-widget' ) ); ?></textarea>
             </p>
             <p>
@@ -665,8 +665,8 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                                     <form action="options.php" method="post">
 
                                         <?php
-                                        settings_fields('tp_twitch');
-                                        tp_twitch_do_settings_sections('tp_twitch');
+                                        settings_fields( 'tp_twitch' );
+                                        tp_twitch_do_settings_sections( 'tp_twitch' );
                                         ?>
 
                                         <p>
@@ -682,9 +682,9 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                             <div id="postbox-container-1" class="postbox-container">
                                 <div class="meta-box-sortables">
                                     <div class="postbox">
-                                        <h3><span><?php _e('Resources &amp; Support', 'tomparisde-twitchtv-widget' ); ?></span></h3>
+                                        <h3><span><?php _e( 'Resources &amp; Support', 'tomparisde-twitchtv-widget' ); ?></span></h3>
                                         <div class="inside">
-                                            <p><?php _e('In order to make it as simple as possible for you, we created a detailed online documentation.', 'tomparisde-twitchtv-widget' ); ?></p>
+                                            <p><?php _e( 'In order to make it as simple as possible for you, we created a detailed online documentation.', 'tomparisde-twitchtv-widget' ); ?></p>
                                             <ul>
                                                 <li>
                                                     <?php
@@ -695,16 +695,16 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                                                         ), TP_TWITCH_DOCS_URL )
                                                     );
                                                     ?>
-                                                    <a href="<?php echo $docs_link; ?>" target="_blank"><?php _e('Documentation', 'tomparisde-twitchtv-widget' ); ?></a>
+                                                    <a href="<?php echo $docs_link; ?>" target="_blank"><?php _e( 'Documentation', 'tomparisde-twitchtv-widget' ); ?></a>
                                                 </li>
                                                 <li>
-                                                    <a href="<?php echo TP_TWITCH_WP_ORG_URL; ?>" target="_blank"><?php _e('Plugin Page', 'tomparisde-twitchtv-widget' ); ?></a>
+                                                    <a href="<?php echo TP_TWITCH_WP_ORG_URL; ?>" target="_blank"><?php _e( 'Plugin Page', 'tomparisde-twitchtv-widget' ); ?></a>
                                                 </li>
                                                 <li>
-                                                    <a href="https://wordpress.org/plugins/tomparisde-twitchtv-widget/#developers" target="_blank"><?php _e('Changelog', 'tomparisde-twitchtv-widget' ); ?></a>
+                                                    <a href="https://wordpress.org/plugins/tomparisde-twitchtv-widget/#developers" target="_blank"><?php _e( 'Changelog', 'tomparisde-twitchtv-widget' ); ?></a>
                                                 </li>
                                                 <li>
-                                                    <a href="https://twitter.com/kryptonitewp" target="_blank"><?php _e('Follow us on Twitter', 'tomparisde-twitchtv-widget' ); ?></a>
+                                                    <a href="https://twitter.com/kryptonitewp" target="_blank"><?php _e( 'Follow us on Twitter', 'tomparisde-twitchtv-widget' ); ?></a>
                                                 </li>
                                             </ul>
                                             <?php
@@ -715,35 +715,35 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                                                 ), 'https://kryptonitewp.com/' )
                                             );
                                             ?>
-                                            <p>&copy; Copyright <?php echo date('Y' ); ?> <a href="<?php echo $website_link; ?>" target="_blank">KryptoniteWP</a></p>
+                                            <p>&copy; Copyright <?php echo date( 'Y' ); ?> <a href="<?php echo $website_link; ?>" target="_blank">KryptoniteWP</a></p>
                                         </div>
                                     </div>
                                 </div>
 
                                 <?php if ( ! tp_twitch_is_pro_version() ) { ?>
                                     <div class="postbox">
-                                        <h3><span><?php _e('Upgrade to PRO Version', 'tomparisde-twitchtv-widget'); ?></span></h3>
+                                        <h3><span><?php _e( 'Upgrade to PRO Version', 'tomparisde-twitchtv-widget' ); ?></span></h3>
                                         <div class="inside">
 
-                                            <p><?php _e('The PRO version extends the plugin exclusively with a variety of different styles and some exclusively features.', 'tomparisde-twitchtv-widget'); ?></p>
+                                            <p><?php _e( 'The PRO version extends the plugin exclusively with a variety of different styles and some exclusively features.', 'tomparisde-twitchtv-widget' ); ?></p>
 
                                             <ul>
-                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e('Display more than 3 streams', 'tomparisde-twitchtv-widget'); ?></strong></li>
-                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e('Place streams via shortcode', 'tomparisde-twitchtv-widget'); ?></strong></li>
-                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e('Choose from different styles', 'tomparisde-twitchtv-widget'); ?></strong></li>
-                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e('Sort streams by different criteria', 'tomparisde-twitchtv-widget'); ?></strong></li>
-                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e('And more!', 'tomparisde-twitchtv-widget'); ?></strong></li>
+                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e( 'Display more than 3 streams', 'tomparisde-twitchtv-widget' ); ?></strong></li>
+                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e( 'Place streams via shortcode', 'tomparisde-twitchtv-widget' ); ?></strong></li>
+                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e( 'Choose from different styles', 'tomparisde-twitchtv-widget' ); ?></strong></li>
+                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e( 'Sort streams by different criteria', 'tomparisde-twitchtv-widget' ); ?></strong></li>
+                                                <li><span class="dashicons dashicons-star-filled"></span> <strong><?php _e( 'And more!', 'tomparisde-twitchtv-widget' ); ?></strong></li>
                                             </ul>
 
                                             <p>
-                                                <?php _e('We would be happy if you give it a chance!', 'tomparisde-twitchtv-widget'); ?>
+                                                <?php _e( 'We would be happy if you give it a chance!', 'tomparisde-twitchtv-widget' ); ?>
                                             </p>
 
                                             <p>
                                                 <?php
                                                 $upgrade_link = tp_twitch_get_pro_version_url( 'settings-page', 'infobox-upgrade' );
                                                 ?>
-                                                <a class="tp-twitch-settings-button tp-twitch-settings-button--block" target="_blank" href="<?php echo $upgrade_link; ?>" rel="nofollow"><?php _e('More details', 'tomparisde-twitchtv-widget'); ?></a>
+                                                <a class="tp-twitch-settings-button tp-twitch-settings-button--block" target="_blank" href="<?php echo $upgrade_link; ?>" rel="nofollow"><?php _e( 'More details', 'tomparisde-twitchtv-widget' ); ?></a>
                                             </p>
                                         </div>
                                     </div>
@@ -766,10 +766,10 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
          */
         private function check_curl() {
 
-            if ( ( function_exists('curl_version') ) ) {
+            if ( ( function_exists( 'curl_version' ) ) ) {
 
                 $curl_data = curl_version();
-                $version = ( isset ( $curl_data['version'] ) ) ? $curl_data['version'] : null;
+                $version   = ( isset ( $curl_data['version'] ) ) ? $curl_data['version'] : null;
 
                 return array(
                     'enabled' => true,
@@ -789,33 +789,33 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
  * 
  * @param $page
  */
-function tp_twitch_do_settings_sections($page)
+function tp_twitch_do_settings_sections( $page)
 {
 
     global $wp_settings_sections, $wp_settings_fields;
 
-    if (!isset($wp_settings_sections[$page]))
+    if ( ! isset( $wp_settings_sections[$page] ) )
         return;
 
-    foreach ((array)$wp_settings_sections[$page] as $section) {
+    foreach ( (array)$wp_settings_sections[$page] as $section ) {
 
         $title = '';
 
-        if ($section['title'])
+        if ( $section['title'] )
             $title = "<h3 class='hndle'>{$section['title']}</h3>\n";
 
-        if (!isset($wp_settings_fields) || !isset($wp_settings_fields[$page]) || ( !isset($wp_settings_fields[$page][$section['id']] ) && ! in_array( $section['id'], array( 'tp_twitch_quickstart', 'tp_twitch_data', 'tp_twitch_help' ) ) ) )
+        if ( ! isset( $wp_settings_fields) || ! isset( $wp_settings_fields[$page] ) || ( ! isset( $wp_settings_fields[$page][$section['id']] ) && ! in_array( $section['id'], array( 'tp_twitch_quickstart', 'tp_twitch_data', 'tp_twitch_help' ) ) ) )
             continue;
 
         echo '<div class="postbox">';
         echo $title;
         echo '<div class="inside">';
 
-        if ($section['callback'])
-            call_user_func($section['callback'], $section);
+        if ( $section['callback'] )
+            call_user_func( $section['callback'], $section);
 
         echo '<table class="form-table">';
-        do_settings_fields($page, $section['id']);
+        do_settings_fields( $page, $section['id'] );
         echo '</table>';
         echo '</div>';
         echo '</div>';

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -606,7 +606,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                 </thead>
                 <tbody>
                 <tr>
-                    <th>Twitch API</th>
+                    <th><?php _e( 'Twitch API', 'tomparisde-twitchtv-widget' ); ?></th>
                     <td>
                         <?php if ( isset( $this->options['api_status'] ) && true === $this->options['api_status'] ) { ?>
                             <span style="font-weight: bold; color: green;"><?php _e( 'Connected', 'tomparisde-twitchtv-widget' ); ?></span>
@@ -670,7 +670,7 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
                                         ?>
 
                                         <p>
-                                            <?php submit_button( 'Save Changes', 'button-primary', 'submit', false ); ?>
+                                            <?php submit_button( __( 'Save Changes', 'tomparisde-twitchtv-widget' ), 'button-primary', 'submit', false ); ?>
                                             <?php submit_button( __( 'Delete Cache', 'tomparisde-twitchtv-widget' ), 'button-secondary', 'tp_twitch_delete_cache_submit', false ); ?>
                                         </p>
 

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -417,10 +417,10 @@ if ( ! class_exists( 'TP_Twitch_Settings' ) ) {
 		 */
 		function no_streams_found_text_render() {
 
-            $no_streams_found_message = ( isset ( $this->options['no_streams_found_text'] ) ) ? $this->options['no_streams_found_text'] : __( 'No streams found', 'tomparisde-twitchtv-widget' );
+            $$no_streams_found_msg = ( isset ( $this->options['no_streams_found_text'] ) ) ? $this->options['no_streams_found_text'] : __( 'No streams found', 'tomparisde-twitchtv-widget' );
 
 			?>
-            <input id="tp_twitch_no_streams_found_text" class="regular-text" name="tp_twitch[no_streams_found_text]" type="text" value="<?php echo esc_html( $no_streams_found_message ); ?>" />
+            <input id="tp_twitch_no_streams_found_text" class="regular-text" name="tp_twitch[no_streams_found_text]" type="text" value="<?php echo esc_html( $$no_streams_found_msg ); ?>" />
             <p class="description">
                 <?php _e( 'Customize the message displayed when they are no available streams.', 'tomparisde-twitchtv-widget' ); ?>
             </p>

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -72,9 +72,9 @@ function tp_twitch_display_streams( $streams_args = array(), $template_args = ar
 		// Load template.
 		if ( $template_file ) {
 
-			 include $template_file;
+			include $template_file;
 
-		 // Template not found.
+		// Template not found.
 		} else {
 			_e( 'Template not found.', 'tomparisde-twitchtv-widget' );
 		}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -82,8 +82,10 @@ function tp_twitch_display_streams( $streams_args = array(), $template_args = ar
 	// No streams found.
 	} else {
 
-		$no_streams_found = tp_twitch_get_option( 'no_streams_found' );
-		$no_streams_found_text = apply_filters( 'tp_twitch_no_streams_found_text', __( 'No streams found.', 'tomparisde-twitchtv-widget' ) );
+		$no_streams_found      = tp_twitch_get_option( 'no_streams_found' );
+		$no_streams_found_text = tp_twitch_get_option( 'no_streams_found_text' );
+		$no_streams_found_text = ( isset ( $no_streams_found_text ) ) ? $no_streams_found_text : __( 'No streams found', 'tomparisde-twitchtv-widget' );
+		$no_streams_found_text = apply_filters( 'tp_twitch_no_streams_found_text', $no_streams_found_text );
 
 		if ( 'show' === $no_streams_found ) {
 			echo $no_streams_found_text;

--- a/languages/tomparisde-twitchtv-widget.pot
+++ b/languages/tomparisde-twitchtv-widget.pot
@@ -3,8 +3,8 @@ msgid ""
 msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "Project-Id-Version: Twitch for WordPress\n"
-"POT-Creation-Date: 2018-09-27 17:24+0700\n"
-"PO-Revision-Date: 2018-09-24 17:41+0700\n"
+"POT-Creation-Date: 2019-09-24 14:25-0400\n"
+"PO-Revision-Date: 2019-09-24 14:25-0400\n"
 "Last-Translator: \n"
 "Language-Team: KryptoniteWP\n"
 "MIME-Version: 1.0\n"
@@ -52,61 +52,65 @@ msgstr ""
 msgid "No Streams Found"
 msgstr ""
 
-#: includes/admin/class-settings.php:123
+#: includes/admin/class-settings.php:121
+msgid "No Streams Found Message"
+msgstr ""
+
+#: includes/admin/class-settings.php:132
 msgid "Default Settings"
 msgstr ""
 
-#: includes/admin/class-settings.php:130 includes/admin/class-settings.php:539
+#: includes/admin/class-settings.php:139 includes/admin/class-settings.php:563
 #: includes/widget.php:165
 msgid "Language"
 msgstr ""
 
-#: includes/admin/class-settings.php:139
+#: includes/admin/class-settings.php:148
 msgid "Style (Widget)"
 msgstr ""
 
-#: includes/admin/class-settings.php:148
+#: includes/admin/class-settings.php:157
 msgid "Size (Widget)"
 msgstr ""
 
-#: includes/admin/class-settings.php:157
+#: includes/admin/class-settings.php:166
 msgid "Preview (Widget)"
 msgstr ""
 
-#: includes/admin/class-settings.php:170
+#: includes/admin/class-settings.php:179
 msgid "API Related Data"
 msgstr ""
 
-#: includes/admin/class-settings.php:177
+#: includes/admin/class-settings.php:186
 msgid "Help & Support"
 msgstr ""
 
-#: includes/admin/class-settings.php:264
+#: includes/admin/class-settings.php:273
 msgid "Step 1: Create API Credentials"
 msgstr ""
 
-#: includes/admin/class-settings.php:265
+#: includes/admin/class-settings.php:274
 #, php-format
 msgid ""
 "Follow our guide which shows you <a href=\"%s\" target=\"_blank\" rel="
 "\"nofollow\">how to create Twitch API credentials</a>."
 msgstr ""
 
-#: includes/admin/class-settings.php:273
+#: includes/admin/class-settings.php:282
 msgid "Step 2: Enter your Client ID"
 msgstr ""
 
-#: includes/admin/class-settings.php:274
+#: includes/admin/class-settings.php:283
 msgid ""
 "Once you created your API credentials, enter your personal <em>Client ID</"
 "em> into the field below."
 msgstr ""
 
-#: includes/admin/class-settings.php:278
+#: includes/admin/class-settings.php:287
 msgid "Step 3: Place Twitch Streams on your Site"
 msgstr ""
 
-#: includes/admin/class-settings.php:279
+#: includes/admin/class-settings.php:288
 #, php-format
 msgid ""
 "Go to the <a href=\"%s\" target=\"_blank\" rel=\"nofollow\">Widgets page</"
@@ -114,114 +118,122 @@ msgid ""
 "your needs."
 msgstr ""
 
-#: includes/admin/class-settings.php:284
+#: includes/admin/class-settings.php:293
 #, php-format
 msgid ""
 "Please take a look into the <a href=\"%s\">documentation</a> for more "
 "options."
 msgstr ""
 
-#: includes/admin/class-settings.php:298
+#: includes/admin/class-settings.php:307
 #, php-format
 msgid ""
 "In order to show Twitch streams, this plugin requires access to the official "
 "<a href=\"%s\" target=\"_blank\" rel=\"nofollow\">Twitch API</a>."
 msgstr ""
 
-#: includes/admin/class-settings.php:311 includes/admin/class-settings.php:588
+#: includes/admin/class-settings.php:320 includes/admin/class-settings.php:612
 msgid "Connected"
 msgstr ""
 
-#: includes/admin/class-settings.php:313 includes/admin/class-settings.php:590
+#: includes/admin/class-settings.php:322 includes/admin/class-settings.php:614
 msgid "Disconnected"
 msgstr ""
 
-#: includes/admin/class-settings.php:332
+#: includes/admin/class-settings.php:341
 #, php-format
 msgid ""
 "We created a detailed guide which shows you <a href=\"%s\" target=\"_blank\" "
 "rel=\"nofollow\">how to get your client id</a>."
 msgstr ""
 
-#: includes/admin/class-settings.php:347
+#: includes/admin/class-settings.php:356
 msgid "Here you set up general settings which will be used plugin wide."
 msgstr ""
 
-#: includes/admin/class-settings.php:357 includes/admin/class-settings.php:358
-#: includes/admin/class-settings.php:359 includes/admin/class-settings.php:360
-#: includes/admin/class-settings.php:361 includes/admin/class-settings.php:362
-#: includes/admin/class-settings.php:363
+#: includes/admin/class-settings.php:366 includes/admin/class-settings.php:367
+#: includes/admin/class-settings.php:368 includes/admin/class-settings.php:369
+#: includes/admin/class-settings.php:370 includes/admin/class-settings.php:371
+#: includes/admin/class-settings.php:372
 #, php-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/admin/class-settings.php:375
+#: includes/admin/class-settings.php:384
 msgid ""
 "In case you're using a caching plugin, it makes no sense to select a lower "
 "value, than the caching interval of your caching plugin."
 msgstr ""
 
-#: includes/admin/class-settings.php:387
+#: includes/admin/class-settings.php:396
 msgid "Hide Message"
 msgstr ""
 
-#: includes/admin/class-settings.php:388
+#: includes/admin/class-settings.php:397
 msgid "Show Message"
 msgstr ""
 
-#: includes/admin/class-settings.php:389
+#: includes/admin/class-settings.php:398
 msgid "Show Message for Admins only"
 msgstr ""
 
-#: includes/admin/class-settings.php:401
+#: includes/admin/class-settings.php:410
 msgid "Specify what happens when no streams were found."
 msgstr ""
 
-#: includes/admin/class-settings.php:412
+#: includes/admin/class-settings.php:420 includes/template-functions.php:87
+msgid "No streams found"
+msgstr ""
+
+#: includes/admin/class-settings.php:425
+msgid "Customize the message displayed when they are no available streams."
+msgstr ""
+
+#: includes/admin/class-settings.php:436
 msgid ""
 "Here you set up the default settings which will be used for displaying "
 "streams and may be overwritten individually."
 msgstr ""
 
-#: includes/admin/class-settings.php:493
+#: includes/admin/class-settings.php:517
 msgid "Here you can find an overview of all available API related data."
 msgstr ""
 
-#: includes/admin/class-settings.php:496
+#: includes/admin/class-settings.php:520
 msgid "Toggle Information"
 msgstr ""
 
-#: includes/admin/class-settings.php:507
+#: includes/admin/class-settings.php:531
 msgid "Games"
 msgstr ""
 
-#: includes/admin/class-settings.php:511
+#: includes/admin/class-settings.php:535
 msgid "ID"
 msgstr ""
 
-#: includes/admin/class-settings.php:512 includes/widget.php:152
+#: includes/admin/class-settings.php:536 includes/widget.php:152
 msgid "Game"
 msgstr ""
 
-#: includes/admin/class-settings.php:534
+#: includes/admin/class-settings.php:558
 msgid "Languages"
 msgstr ""
 
-#: includes/admin/class-settings.php:538
+#: includes/admin/class-settings.php:562
 msgid "Code"
 msgstr ""
 
-#: includes/admin/class-settings.php:568
+#: includes/admin/class-settings.php:592
 msgid "Enabled"
 msgstr ""
 
-#: includes/admin/class-settings.php:569
+#: includes/admin/class-settings.php:593
 msgid "Disabled"
 msgstr ""
 
-#: includes/admin/class-settings.php:573
+#: includes/admin/class-settings.php:597
 #, php-format
 msgid ""
 "In case you experience some issue with our plugin, please <a href=\"%s\" "
@@ -229,104 +241,112 @@ msgid ""
 "table below."
 msgstr ""
 
-#: includes/admin/class-settings.php:579
+#: includes/admin/class-settings.php:603
 msgid "Setting"
 msgstr ""
 
-#: includes/admin/class-settings.php:580
+#: includes/admin/class-settings.php:604
 msgid "Values"
 msgstr ""
 
-#: includes/admin/class-settings.php:603
+#: includes/admin/class-settings.php:609
+msgid "Twitch API"
+msgstr ""
+
+#: includes/admin/class-settings.php:627
 #, php-format
 msgid "PHP \"%1$s\" extension"
 msgstr ""
 
-#: includes/admin/class-settings.php:613
+#: includes/admin/class-settings.php:637
 msgid ""
 "In case one of the values above is <span style=\"color: red;\"><strong>red</"
 "strong></span>, please get in contact with your webhoster in order to enable "
 "the missing PHP extensions."
 msgstr ""
 
-#: includes/admin/class-settings.php:617
+#: includes/admin/class-settings.php:641
 msgid "Log file"
 msgstr ""
 
-#: includes/admin/class-settings.php:618
+#: includes/admin/class-settings.php:642
 msgid "No entries yet. "
 msgstr ""
 
 #. Plugin Name of the plugin/theme
-#: includes/admin/class-settings.php:635
+#: includes/admin/class-settings.php:659
 msgid "Twitch for WordPress"
 msgstr ""
 
-#: includes/admin/class-settings.php:650
+#: includes/admin/class-settings.php:673
+msgid "Save Changes"
+msgstr ""
+
+#: includes/admin/class-settings.php:674
 msgid "Delete Cache"
 msgstr ""
 
-#: includes/admin/class-settings.php:661
+#: includes/admin/class-settings.php:685
 msgid "Resources &amp; Support"
 msgstr ""
 
-#: includes/admin/class-settings.php:663
+#: includes/admin/class-settings.php:687
 msgid ""
 "In order to make it as simple as possible for you, we created a detailed "
 "online documentation."
 msgstr ""
 
-#: includes/admin/class-settings.php:674 includes/admin/plugins.php:51
+#: includes/admin/class-settings.php:698 includes/admin/plugins.php:51
 msgid "Documentation"
 msgstr ""
 
-#: includes/admin/class-settings.php:677
+#: includes/admin/class-settings.php:701
 msgid "Plugin Page"
 msgstr ""
 
-#: includes/admin/class-settings.php:680
+#: includes/admin/class-settings.php:704
 msgid "Changelog"
 msgstr ""
 
-#: includes/admin/class-settings.php:683
+#: includes/admin/class-settings.php:707
 msgid "Follow us on Twitter"
 msgstr ""
 
-#: includes/admin/class-settings.php:701
+#: includes/admin/class-settings.php:725
 msgid "Upgrade to PRO Version"
 msgstr ""
 
-#: includes/admin/class-settings.php:704
+#: includes/admin/class-settings.php:728
 msgid ""
 "The PRO version extends the plugin exclusively with a variety of different "
 "styles and some exclusively features."
 msgstr ""
 
-#: includes/admin/class-settings.php:707
+#: includes/admin/class-settings.php:731
 msgid "Display more than 3 streams"
 msgstr ""
 
-#: includes/admin/class-settings.php:708
+#: includes/admin/class-settings.php:732
 msgid "Place streams via shortcode"
 msgstr ""
 
-#: includes/admin/class-settings.php:709
+#: includes/admin/class-settings.php:733
 msgid "Choose from different styles"
 msgstr ""
 
-#: includes/admin/class-settings.php:710
+#: includes/admin/class-settings.php:734
 msgid "Sort streams by different criteria"
 msgstr ""
 
-#: includes/admin/class-settings.php:711
+#: includes/admin/class-settings.php:735
 msgid "And more!"
 msgstr ""
 
-#: includes/admin/class-settings.php:715
+#: includes/admin/class-settings.php:739
 msgid "We would be happy if you give it a chance!"
 msgstr ""
 
-#: includes/admin/class-settings.php:722
+#: includes/admin/class-settings.php:746
 msgid "More details"
 msgstr ""
 
@@ -368,168 +388,168 @@ msgstr ""
 msgid "Twitch stream of %s"
 msgstr ""
 
-#: includes/functions.php:171 includes/functions.php:250
+#: includes/functions.php:175 includes/functions.php:254
 msgid "Please select..."
 msgstr ""
 
-#: includes/functions.php:183
+#: includes/functions.php:187
 msgid "Please connect to API first..."
 msgstr ""
 
-#: includes/functions.php:200
+#: includes/functions.php:204
 msgid "Danish"
 msgstr ""
 
-#: includes/functions.php:201
+#: includes/functions.php:205
 msgid "German"
 msgstr ""
 
-#: includes/functions.php:202
+#: includes/functions.php:206
 msgid "English"
 msgstr ""
 
-#: includes/functions.php:203
+#: includes/functions.php:207
 msgid "English (UK)"
 msgstr ""
 
-#: includes/functions.php:204
+#: includes/functions.php:208
 msgid "Spanish"
 msgstr ""
 
-#: includes/functions.php:205
+#: includes/functions.php:209
 msgid "Spanish (Latin American)"
 msgstr ""
 
-#: includes/functions.php:206
+#: includes/functions.php:210
 msgid "French"
 msgstr ""
 
-#: includes/functions.php:207
+#: includes/functions.php:211
 msgid "Italian"
 msgstr ""
 
-#: includes/functions.php:208
+#: includes/functions.php:212
 msgid "Hungarian"
 msgstr ""
 
-#: includes/functions.php:209
+#: includes/functions.php:213
 msgid "Dutch"
 msgstr ""
 
-#: includes/functions.php:210
+#: includes/functions.php:214
 msgid "Norwegian"
 msgstr ""
 
-#: includes/functions.php:211
+#: includes/functions.php:215
 msgid "Polish"
 msgstr ""
 
-#: includes/functions.php:212
+#: includes/functions.php:216
 msgid "Portuguese"
 msgstr ""
 
-#: includes/functions.php:213
+#: includes/functions.php:217
 msgid "Portuguese (Brazil)"
 msgstr ""
 
-#: includes/functions.php:214
+#: includes/functions.php:218
 msgid "Slovenian"
 msgstr ""
 
-#: includes/functions.php:215
+#: includes/functions.php:219
 msgid "Finnish"
 msgstr ""
 
-#: includes/functions.php:216
+#: includes/functions.php:220
 msgid "Swedish"
 msgstr ""
 
-#: includes/functions.php:217
+#: includes/functions.php:221
 msgid "Vietnamese"
 msgstr ""
 
-#: includes/functions.php:218
+#: includes/functions.php:222
 msgid "Turkish"
 msgstr ""
 
-#: includes/functions.php:219
+#: includes/functions.php:223
 msgid "Czech"
 msgstr ""
 
-#: includes/functions.php:220
+#: includes/functions.php:224
 msgid "Greek"
 msgstr ""
 
-#: includes/functions.php:221
+#: includes/functions.php:225
 msgid "Bulgarian"
 msgstr ""
 
-#: includes/functions.php:222
+#: includes/functions.php:226
 msgid "Russian"
 msgstr ""
 
-#: includes/functions.php:223
+#: includes/functions.php:227
 msgid "Arabic"
 msgstr ""
 
-#: includes/functions.php:224
+#: includes/functions.php:228
 msgid "Thai"
 msgstr ""
 
-#: includes/functions.php:225
+#: includes/functions.php:229
 msgid "Chinese"
 msgstr ""
 
-#: includes/functions.php:226
+#: includes/functions.php:230
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#: includes/functions.php:227
+#: includes/functions.php:231
 msgid "Japanese"
 msgstr ""
 
-#: includes/functions.php:228
+#: includes/functions.php:232
 msgid "Korean"
 msgstr ""
 
-#: includes/functions.php:229
+#: includes/functions.php:233
 msgid "Hindi"
 msgstr ""
 
-#: includes/functions.php:230
+#: includes/functions.php:234
 msgid "Romanian"
 msgstr ""
 
-#: includes/functions.php:267 includes/functions.php:284
-#: includes/functions.php:301
+#: includes/functions.php:271 includes/functions.php:288
+#: includes/functions.php:305
 msgid "Standard (Settings Page)"
 msgstr ""
 
-#: includes/functions.php:269
+#: includes/functions.php:273
 msgid "Default"
 msgstr ""
 
-#: includes/functions.php:286
+#: includes/functions.php:290
 msgid "Large"
 msgstr ""
 
-#: includes/functions.php:287
+#: includes/functions.php:291
 msgid "Small"
 msgstr ""
 
-#: includes/functions.php:288
+#: includes/functions.php:292
 msgid "First Large, Others Small"
 msgstr ""
 
-#: includes/functions.php:303
+#: includes/functions.php:307
 msgid "Image"
 msgstr ""
 
-#: includes/functions.php:304
+#: includes/functions.php:308
 msgid "Video"
 msgstr ""
 
-#: includes/functions.php:305
+#: includes/functions.php:309
 msgid "First Video, Others Images"
 msgstr ""
 
@@ -554,10 +574,6 @@ msgstr ""
 
 #: includes/template-functions.php:79
 msgid "Template not found."
-msgstr ""
-
-#: includes/template-functions.php:86
-msgid "No streams found."
 msgstr ""
 
 #: includes/widget.php:23
@@ -654,7 +670,7 @@ msgid "https://de.wordpress.org/plugins/tomparisde-twitchtv-widget/"
 msgstr ""
 
 #. Description of the plugin/theme
-msgid "Display Twitch streams on your WordPress site."
+msgid "Display Twitch streams on your sidebars."
 msgstr ""
 
 #. Author of the plugin/theme


### PR DESCRIPTION
This PR addresses issue #12 and adds the settings field for users to type in a custom message for the "No streams found" text, updates text strings for localization and general code cleanup.

If no custom text is added to the settings field, "No streams found" is used as default text.